### PR TITLE
Event may not contain headers

### DIFF
--- a/zappa_sentry/__init__.py
+++ b/zappa_sentry/__init__.py
@@ -27,10 +27,13 @@ def unhandled_exceptions(e, event, context):
         if 'httpMethod' in event:
             scope.set_tag('http_method', event['httpMethod'])
             scope.set_tag('path', event['path'])
-        if 'Host' in event['headers']:
-            scope.set_tag('host', event['headers']['Host'])
-        if 'User-Agent' in event['headers']:
-            scope.set_tag('user_agent', event['headers']['User-Agent'])
+
+        if 'headers' in event:
+            if 'Host' in event['headers']:
+                scope.set_tag('host', event['headers']['Host'])
+            if 'User-Agent' in event['headers']:
+                scope.set_tag('user_agent', event['headers']['User-Agent'])
+
         if 'requestContext' in event and 'stage' in event['requestContext']:
             scope.set_tag('stage', event['requestContext']['stage'])
 


### PR DESCRIPTION
There are a few ways to invoke functions (`threading` module, async tasks, scheduled tasks) that are outside of an HTTP request context.

This exception handler fails in such situations. Checking for `headers` prevents a `KeyError` here.